### PR TITLE
Add client comments

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -78,3 +78,18 @@ button {
 .nav-buttons button {
   margin-right: 0.5rem;
 }
+#client-comments {
+  margin-top: 2rem;
+}
+
+#client-comments h3 {
+  margin-bottom: 0.75rem;
+  color: var(--color-accent);
+}
+
+.comment-box {
+  background: #f7f7f8;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}

--- a/guion2.html
+++ b/guion2.html
@@ -74,6 +74,15 @@
         </div>
         <button id="unlock-btn">Cargar otro guion (requiere contraseña)</button>
       </section>
+      <section id="client-comments">
+        <h3>Comentarios del cliente</h3>
+        <div id="comments-container"></div>
+        <form id="comment-form">
+          <input type="password" id="comment-key" placeholder="Clave" required>
+          <textarea id="comment-text" rows="2" placeholder="Escribe un comentario" required></textarea>
+          <button type="submit">Enviar</button>
+        </form>
+      </section>
   </main>
   <script src="js/app.js"></script>
 </body>

--- a/guion3.html
+++ b/guion3.html
@@ -74,6 +74,15 @@
         </div>
         <button id="unlock-btn">Cargar otro guion (requiere contraseña)</button>
       </section>
+      <section id="client-comments">
+        <h3>Comentarios del cliente</h3>
+        <div id="comments-container"></div>
+        <form id="comment-form">
+          <input type="password" id="comment-key" placeholder="Clave" required>
+          <textarea id="comment-text" rows="2" placeholder="Escribe un comentario" required></textarea>
+          <button type="submit">Enviar</button>
+        </form>
+      </section>
   </main>
   <script src="js/app.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,15 @@
         </div>
         <button id="unlock-btn">Cargar otro guion (requiere contraseña)</button>
       </section>
+      <section id="client-comments">
+        <h3>Comentarios del cliente</h3>
+        <div id="comments-container"></div>
+        <form id="comment-form">
+          <input type="password" id="comment-key" placeholder="Clave" required>
+          <textarea id="comment-text" rows="2" placeholder="Escribe un comentario" required></textarea>
+          <button type="submit">Enviar</button>
+        </form>
+      </section>
   </main>
   <script src="js/app.js"></script>
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,6 @@
 // Configuración
 const pwd = 'verite2025'; // Cambiar en producción
+const commentPwd = "comentarios2025";
 
 // Navegación entre guiones
 const prevBtn = document.getElementById('prev-btn');
@@ -38,6 +39,10 @@ const hdrTipo        = document.getElementById('hdr-tipo');
 const hdrComments    = document.getElementById('hdr-comentarios');
 const scriptContent  = document.getElementById('script-content');
 
+const commentsContainer = document.getElementById("comments-container");
+const commentForm = document.getElementById("comment-form");
+const commentKey = document.getElementById("comment-key");
+const commentText = document.getElementById("comment-text");
 // Al cargar, trato de obtener datos de Firestore
 docRef.get().then(doc => {
   if (doc.exists) {
@@ -88,3 +93,19 @@ unlockBtn.addEventListener('click', () => {
     alert('Contraseña incorrecta.');
   }
 });
+
+// Comentarios del cliente
+if (commentForm) {
+  commentForm.addEventListener('submit', e => {
+    e.preventDefault();
+    if (commentKey.value === commentPwd) {
+      const div = document.createElement('div');
+      div.className = 'comment-box';
+      div.textContent = commentText.value;
+      commentsContainer.appendChild(div);
+      commentText.value = '';
+    } else {
+      alert('Clave incorrecta.');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a comment section to each HTML page so clients can post messages with the key `comentarios2025`
- style comment boxes similar to ChatGPT message boxes
- handle comment form logic in `js/app.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871348dee3c832588f7e31d9afed618