### PR TITLE
Agregar persistencia de comentarios con Firebase

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -93,3 +93,10 @@ button {
   border-radius: 8px;
   margin-bottom: 1rem;
 }
+
+.delete-btn {
+  display: block;
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- persist comments in Firestore so they survive page reloads
- add a small delete button for each comment
- protect delete action with the same comment password
- style delete button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871397612948325a9efd4191d39f6e1